### PR TITLE
remover dominio, protocolo implícito

### DIFF
--- a/Corredores.html
+++ b/Corredores.html
@@ -12,7 +12,7 @@
     <script>
         function debut() {
             // leeJson(".\corredores18",mstCorredores)
-            accede("GET","localhost:3000/corredores",mstCorredores)
+            accede("GET","/corredores",mstCorredores)
         }
         function mstCorredores(datos) {
             mstTabla


### PR DESCRIPTION
Cuando realizamos una petición xhr tenemos que explicitamente especificar el protocolo, __a no ser que estemos realizando la llamada al mismo host, en tal caso tenemos que omitir el dominio y exclusivamente especificar el path.__

Si por el contrario espeficamos el dominio, el navegador tratará de resolver directamente la url y esta no contiene el protocolo. 